### PR TITLE
Store runid, best_average_loss and time stamp in generated file.

### DIFF
--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -79,6 +79,22 @@
     }
   },
   "parameters": {
+    "AMPLIFY_function_wandbHistory_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "wandbHistory"
+        }
+      ]
+    },
+    "AMPLIFY_function_wandbHistory_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "wandbHistory"
+        }
+      ]
+    },
     "AMPLIFY_function_wandbHistory_wandbApiKey": {
       "usedBy": [
         {

--- a/amplify/backend/function/wandbhistory/src/index.py
+++ b/amplify/backend/function/wandbhistory/src/index.py
@@ -1,7 +1,7 @@
 import json
 from utils.upload import upload
 from utils.script import init_wandb, calculate_best_average_loss
-import os
+
 def handler(event, context):
     all_run_data = init_wandb()
     output = calculate_best_average_loss(all_run_data)

--- a/amplify/backend/function/wandbhistory/src/utils/script.py
+++ b/amplify/backend/function/wandbhistory/src/utils/script.py
@@ -56,7 +56,6 @@ def calculate_best_average_loss(data):
                                 "timestamp": timestamp,
                                 "key":key
                             })
-                            item["best_average_loss"] = best_average_loss
     return output  
 
 def init_wandb():

--- a/amplify/backend/function/wandbhistory/src/utils/script.py
+++ b/amplify/backend/function/wandbhistory/src/utils/script.py
@@ -15,7 +15,7 @@ now = datetime.datetime.now()
 runs = api.runs(f"{entity_name}/{project_name}",
   filters={
     "created_at":{
-    "$gte":(now  - datetime.timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S")
+    "$gte":(now  - datetime.timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S") # fetch data for previous 7 days
   },
   # TODO: add  name filter
   })
@@ -33,12 +33,14 @@ def replace_inf_nan(obj):
         return obj
 
 def calculate_best_average_loss(data):
+    output=[]
     if(isinstance(data, dict)):
-        for items in data.values():
+        for key, items in data.items():
             for item in items:
                 if(isinstance(item, dict)):
                     uids = item.get("uids", [])
                     uid_data = item.get("uid_data", {})
+                    timestamp=item.get("timestamp",None)
                     if(isinstance(uids, list) and isinstance(uid_data, dict)):
                         average_losses = []
                         for uid in uids:
@@ -49,8 +51,13 @@ def calculate_best_average_loss(data):
                                     average_losses.append(average_loss)
                         if(len(average_losses) > 0):
                             best_average_loss = min(average_losses)
+                            output.append({
+                                "best_average_loss": best_average_loss,
+                                "timestamp": timestamp,
+                                "key":key
+                            })
                             item["best_average_loss"] = best_average_loss
-    return data  
+    return output  
 
 def init_wandb():
   all_run_data = {}

--- a/amplify/backend/function/wandbhistory/wandbhistory-cloudformation-template.json
+++ b/amplify/backend/function/wandbhistory/wandbhistory-cloudformation-template.json
@@ -1,225 +1,298 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "Lambda Function resource stack creation using Amplify CLI",
-    "Parameters": {
-        "CloudWatchRule": {
-            "Type": "String",
-            "Default" : "NONE",
-            "Description" : " Schedule Expression"
-        },
-        "deploymentBucketName": {
-            "Type": "String"
-        },
-        "env": {
-            "Type": "String"
-        },
-        "s3Key": {
-            "Type": "String"
-        }
-        
-        ,
-        "wandbApiKey": {
-            "Type": "String"
-        }
-        
-        
-        ,
-    
-    
-    
-        "storages359bce836BucketName": {
-            "Type": "String",
-            "Default": "storages359bce836BucketName"
-            }
-        
-    
-        
-    
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "{\"createdOn\":\"Windows\",\"createdBy\":\"Amplify\",\"createdWith\":\"12.8.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Parameters": {
+    "CloudWatchRule": {
+      "Type": "String",
+      "Default": "NONE",
+      "Description": " Schedule Expression"
     },
-    "Conditions": {
-        "ShouldNotCreateEnvResources": {
-            "Fn::Equals": [
-                {
-                    "Ref": "env"
-                },
-                "NONE"
-            ]
-        }
+    "deploymentBucketName": {
+      "Type": "String"
     },
-    "Resources": {
-        "LambdaFunction": {
-          "Type": "AWS::Lambda::Function",
-          "Metadata": {
-            "aws:asset:path": "./src",
-            "aws:asset:property": "Code"
+    "env": {
+      "Type": "String"
+    },
+    "s3Key": {
+      "Type": "String"
+    },
+    "wandbApiKey": {
+      "Type": "String"
+    },
+    "storages359bce836BucketName": {
+      "Type": "String",
+      "Default": "storages359bce836BucketName"
+    }
+  },
+  "Conditions": {
+    "ShouldNotCreateEnvResources": {
+      "Fn::Equals": [
+        {
+          "Ref": "env"
+        },
+        "NONE"
+      ]
+    }
+  },
+  "Resources": {
+    "LambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "aws:asset:path": "./src",
+        "aws:asset:property": "Code"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "deploymentBucketName"
           },
-          "Properties": {
-            "Code": {
-                "S3Bucket": {
-                    "Ref": "deploymentBucketName"
-                },
-                "S3Key": {
-                    "Ref": "s3Key"
-                }
-            },
-            "Handler": "index.handler",
-            "FunctionName": {
-                "Fn::If": [
-                    "ShouldNotCreateEnvResources",
-                    "wandbHistory",
-                    {
-
-                        "Fn::Join": [
-                            "",
-                            [
-                                "wandbHistory",
-                                "-",
-                                {
-                                    "Ref": "env"
-                                }
-                            ]
-                        ]
-                    }
-                ]
-            },
-            "Environment": {
-                "Variables" : {"ENV":{"Ref":"env"},"REGION":{"Ref":"AWS::Region"},"STORAGE_S359BCE836_BUCKETNAME":{"Ref":"storages359bce836BucketName"},"WANDB_API_KEY":{"Ref":"wandbApiKey"}}
-            },
-            "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "python3.8",
-            "Layers": [],
-            "Timeout": 25
+          "S3Key": {
+            "Ref": "s3Key"
           }
         },
-        "LambdaExecutionRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "RoleName": {
-                    "Fn::If": [
-                        "ShouldNotCreateEnvResources",
-                        "pretrainingLambdaRole64f7bfed",
-                        {
-
-                            "Fn::Join": [
-                                "",
-                                [
-                                    "pretrainingLambdaRole64f7bfed",
-                                    "-",
-                                    {
-                                        "Ref": "env"
-                                    }
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": [
-                                    "lambda.amazonaws.com"
-                                ]
-                            },
-                            "Action": [
-                                "sts:AssumeRole"
-                            ]
-                        }
-                    ]
-                }
+        "Handler": "index.handler",
+        "FunctionName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            "wandbHistory",
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "wandbHistory",
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
             }
-        }
-        ,"lambdaexecutionpolicy": {
-            "DependsOn": ["LambdaExecutionRole"],
-            "Type": "AWS::IAM::Policy",
-            "Properties": {
-                "PolicyName": "lambda-execution-policy",
-                "Roles": [{ "Ref": "LambdaExecutionRole" }],
-                "PolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Action": ["logs:CreateLogGroup",
-                            "logs:CreateLogStream",
-                            "logs:PutLogEvents"],
-                            "Resource": { "Fn::Sub": [ "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*", { "region": {"Ref": "AWS::Region"}, "account": {"Ref": "AWS::AccountId"}, "lambda": {"Ref": "LambdaFunction"}} ]}
-                        }
-                    ]
-                }
+          ]
+        },
+        "Environment": {
+          "Variables": {
+            "ENV": {
+              "Ref": "env"
+            },
+            "REGION": {
+              "Ref": "AWS::Region"
+            },
+            "STORAGE_S359BCE836_BUCKETNAME": {
+              "Ref": "storages359bce836BucketName"
+            },
+            "WANDB_API_KEY": {
+              "Ref": "wandbApiKey"
             }
-        }
-        ,"AmplifyResourcesPolicy": {
-            "DependsOn": ["LambdaExecutionRole"],
-            "Type": "AWS::IAM::Policy",
-            "Properties": {
-                "PolicyName": "amplify-lambda-execution-policy",
-                "Roles": [{ "Ref": "LambdaExecutionRole" }],
-                "PolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [{"Effect":"Allow","Action":["s3:PutObject"],"Resource":[{"Fn::Join":["",["arn:aws:s3:::",{"Ref":"storages359bce836BucketName"},"/*"]]}]}]
-                }
-            }
-        }
-        
-        
-        
-        ,"CloudWatchEvent": {
-            "Type": "AWS::Events::Rule",
-            "Properties": {
-                "Description": "Schedule rule for Lambda",
-                "ScheduleExpression": {
-                    "Ref": "CloudWatchRule"
-                },
-                "State": "ENABLED",
-                "Targets": [{
-                    "Arn": { "Fn::GetAtt": ["LambdaFunction", "Arn"] },
-                    "Id": {
-                        "Ref": "LambdaFunction"
-                    }
-                }]
-            }
-        }
-        ,"PermissionForEventsToInvokeLambda": {
-            "Type": "AWS::Lambda::Permission",
-            "Properties": {
-                "FunctionName": {
-                    "Ref": "LambdaFunction"
-                    },
-                "Action": "lambda:InvokeFunction",
-                "Principal": "events.amazonaws.com",
-                "SourceArn": { "Fn::GetAtt": ["CloudWatchEvent", "Arn"] }
-            }
-        }
-        
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Layers": [],
+        "Timeout": 25
+      }
     },
-    "Outputs": {
-        "Name": {
-            "Value": {
-                "Ref": "LambdaFunction"
+    "LambdaExecutionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": {
+          "Fn::If": [
+            "ShouldNotCreateEnvResources",
+            "pretrainingLambdaRole64f7bfed",
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "pretrainingLambdaRole64f7bfed",
+                  "-",
+                  {
+                    "Ref": "env"
+                  }
+                ]
+              ]
             }
+          ]
         },
-        "Arn": {
-            "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
-        },
-        "Region": {
-            "Value": {
-                "Ref": "AWS::Region"
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
             }
-        },
-        "LambdaExecutionRole": {
-            "Value": {
-                "Ref": "LambdaExecutionRole"
-            }
+          ]
         }
-        
-        ,"CloudWatchEventRule": {
-            "Value": {
-                "Ref": "CloudWatchEvent"
+      }
+    },
+    "lambdaexecutionpolicy": {
+      "DependsOn": [
+        "LambdaExecutionRole"
+      ],
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "lambda-execution-policy",
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ],
+              "Resource": {
+                "Fn::Sub": [
+                  "arn:aws:logs:${region}:${account}:log-group:/aws/lambda/${lambda}:log-stream:*",
+                  {
+                    "region": {
+                      "Ref": "AWS::Region"
+                    },
+                    "account": {
+                      "Ref": "AWS::AccountId"
+                    },
+                    "lambda": {
+                      "Ref": "LambdaFunction"
+                    }
+                  }
+                ]
+              }
             }
+          ]
         }
-        
+      }
+    },
+    "AmplifyResourcesPolicy": {
+      "DependsOn": [
+        "LambdaExecutionRole"
+      ],
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "amplify-lambda-execution-policy",
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:PutObject"
+              ],
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "storages359bce836BucketName"
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CloudWatchEvent": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Schedule rule for Lambda",
+        "ScheduleExpression": {
+          "Ref": "CloudWatchRule"
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "LambdaFunction",
+                "Arn"
+              ]
+            },
+            "Id": {
+              "Ref": "LambdaFunction"
+            }
+          }
+        ]
+      }
+    },
+    "PermissionForEventsToInvokeLambda": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "LambdaFunction"
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "CloudWatchEvent",
+            "Arn"
+          ]
+        }
+      }
     }
+  },
+  "Outputs": {
+    "Name": {
+      "Value": {
+        "Ref": "LambdaFunction"
+      }
+    },
+    "Arn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaFunction",
+          "Arn"
+        ]
+      }
+    },
+    "Region": {
+      "Value": {
+        "Ref": "AWS::Region"
+      }
+    },
+    "LambdaExecutionRole": {
+      "Value": {
+        "Ref": "LambdaExecutionRole"
+      }
+    },
+    "CloudWatchEventRule": {
+      "Value": {
+        "Ref": "CloudWatchEvent"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
+      }
+    }
+  }
 }

--- a/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -18,6 +18,14 @@ export type AmplifyDependentResourcesAttributes = {
       "LambdaExecutionRoleArn": "string",
       "Name": "string",
       "Region": "string"
+    },
+    "wandbHistory": {
+      "Arn": "string",
+      "CloudWatchEventRule": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
     }
   },
   "storage": {

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -15,11 +15,13 @@
       "function": {
         "wandb": {
           "deploymentBucketName": "amplify-pretraining-prod-115707-deployment",
-          "s3Key": "amplify-builds/wandb-4b6a4434586c35343230-build.zip",
+          "s3Key": "amplify-builds/wandb-4574323964394b526362-build.zip",
           "wandbApiKey": "d99387d278a657c2e12313a7758ac33f3de8fd26"
         },
         "wandbHistory": {
-          "wandbApiKey": "d99387d278a657c2e12313a7758ac33f3de8fd26"
+          "wandbApiKey": "d99387d278a657c2e12313a7758ac33f3de8fd26",
+          "deploymentBucketName": "amplify-pretraining-prod-115707-deployment",
+          "s3Key": "amplify-builds/wandbHistory-5a4672446f2f2f36414b-build.zip"
         }
       },
       "auth": {


### PR DESCRIPTION
#### QA Checklist (To be filled by the author):

- [ ] Screenshot/video uploaded
- [ ] No new errors in the browser console
- [ ] `yarn`
- [ ] `yarn compile`
- [ ] `yarn build`
- [ ] `yarn lint`
- [ ] `yarn pretty`

#### QA Checklist (To be filled by one of the reviewers):

- [ ] `yarn`
- [ ] `yarn compile`
- [ ] `yarn build`
- [ ] `yarn lint`
- [ ] `yarn pretty`
